### PR TITLE
Update login-ldap.php (fix: array_shift expected parameter to be array, null given)

### DIFF
--- a/login-ldap.php
+++ b/login-ldap.php
@@ -181,11 +181,16 @@ class LoginLDAPPlugin extends Plugin
 
                     foreach ($groups as $group) {
                         $attributes = $group->getAttributes();
-                        $user_group = array_shift($attributes[$group_indentifier]);
-                        $user_groups[] = $user_group;
+                        
+                        // make sure we have an array to read
+                        if ( !empty($attributes) && !empty($attributes[$group_indentifier]) && is_array($attributes[$group_indentifier]) )
+                        {
+                            $user_group = array_shift($attributes[$group_indentifier]);
+                            $user_groups[] = $user_group;
 
-                        if ($this->config->get('plugins.login-ldap.store_ldap_data', false)) {
-                            $userdata['ldap']['groups'][] = $user_group;
+                            if ($this->config->get('plugins.login-ldap.store_ldap_data', false)) {
+                                $userdata['ldap']['groups'][] = $user_group;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In some rare occasions, the ldap setup can return null when reading the $attributes[$group_indentifier].

By checking that it isn't empty before shifting the array, we prevent the following error:

* array_shift expected parameter to be array, null given