### PR TITLE
Ignore authentication requests with empty username

### DIFF
--- a/login-ldap.php
+++ b/login-ldap.php
@@ -69,6 +69,12 @@ class LoginLDAPPlugin extends Plugin
     public function userLoginAuthenticate(UserLoginEvent $event)
     {
         $credentials = $event->getCredentials();
+        
+        // empty username -> ignore
+        if($credentials['username'] == ''){
+            $event->setStatus($event::AUTHENTICATION_FAILURE);
+            return;
+        }
 
         // Get Proper username
         $user_dn            = $this->config->get('plugins.login-ldap.user_dn');


### PR DESCRIPTION
When using login-ldap with the admin panel I get an LDAP exception because the query is invalid. It looks like the plugin sends an empty login request when loading the admin login page. This causes an invalid query.