### PR TITLE
Feature: Add "ssl ignore errors" for self-signed certs

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -84,6 +84,17 @@ form:
                   validate:
                       type: bool
 
+                ignore_ssl_errors:
+                  type: toggle
+                  label: Ignore SSL Errors
+                  default: false
+                  highlight: 0
+                  options:
+                      1: PLUGIN_ADMIN.YES
+                      0: PLUGIN_ADMIN.NO
+                  validate:
+                      type: bool
+
                 start_tls:
                   type: toggle
                   label: PLUGIN_LOGIN_LDAP.NEGOTIATE_TLS

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -87,6 +87,7 @@ form:
                 ignore_ssl_errors:
                   type: toggle
                   label: Ignore SSL Errors
+                  help: Ignore errors from self-signed certificates.
                   default: false
                   highlight: 0
                   options:

--- a/login-ldap.php
+++ b/login-ldap.php
@@ -94,6 +94,7 @@ class LoginLDAPPlugin extends Plugin
         $start_tls          = $this->config->get('plugins.login-ldap.start_tls');
         $opt_referrals      = $this->config->get('plugins.login-ldap.opt_referrals');
         $blacklist          = $this->config->get('plugins.login-ldap.blacklist_ldap_fields', []);
+        $ignore_ssl_error   = $this->config->get('plugins.login-ldap.ignore_ssl_errors');
 
         if (is_null($host)) {
             throw new ConnectionException('FATAL: LDAP host entry missing in plugin configuration...');
@@ -106,6 +107,10 @@ class LoginLDAPPlugin extends Plugin
             $encryption = 'tls';
         } else {
             $encryption = 'none';
+        }
+
+        if ($ignore_ssl_error) {
+            putenv('LDAPTLS_REQCERT=never');
         }
 
         try {

--- a/login-ldap.yaml
+++ b/login-ldap.yaml
@@ -3,6 +3,7 @@ host:
 port: 389
 version: 3
 ssl: false
+ignore_ssl_errors: false
 start_tls: false
 opt_referrals: false
 user_dn: 'uid=[username],dc=company,dc=com'


### PR DESCRIPTION
Those with internal CA's will have self-signed certificates.  This PR instructs the ldaps to ignore ssl certificate errors, if enabled.