### PR TITLE
Stop event propagation on empty username

### DIFF
--- a/login-ldap.php
+++ b/login-ldap.php
@@ -70,10 +70,11 @@ class LoginLDAPPlugin extends Plugin
     public function userLoginAuthenticate(UserLoginEvent $event)
     {
         $credentials = $event->getCredentials();
-        
-        // empty username -> ignore
+
+        // Fail early on empty username
         if($credentials['username'] == ''){
             $event->setStatus($event::AUTHENTICATION_FAILURE);
+            $event->stopPropagation();
             return;
         }
 


### PR DESCRIPTION
This is inline how authentication fails elsewhere in this plugin.