### PR TITLE
Fix plugin installation under PHP 8.1

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -220,7 +220,6 @@ form:
 
             blacklist_ldap_fields:
               type: array
-              type: array
               value_only: true
               label: PLUGIN_LOGIN_LDAP.BLACKLIST_FIELDS
               help: PLUGIN_LOGIN_LDAP.BLACKLIST_FIELDS_HELP


### PR DESCRIPTION
This double field produces the following error installing plugin under PHP 8.1:

```
Preparing to install https://getgrav.org/download/plugins/login-ldap/1.0.2
  |- Downloading package...   100%    0%
  |- Extracting package...    ok

In AbstractFile.php line 310:

  Failed to read /var/www/html/tmp/Grav-661e4eecb1b45/trilbymedia-grav-plugin-login-ldap-67af8ee/blueprints.yaml: Duplicate key "type" detected at line 223 (near "type: array").


In Parser.php line 357:

  Duplicate key "type" detected at line 223 (near "type: array").
```